### PR TITLE
Add ./dist/* subpath to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 				"types": "./dist/types/index.d.ts",
 				"default": "./dist/index.js"
 			}
-		}
+		},
+		"./dist/*": "./dist/*"
 	},
 	"scripts": {
 		"build": "rm -rf ./dist && tsc",


### PR DESCRIPTION
## What

Adds a `./dist/*` subpath to the package `exports` map so built modules can be imported by deep path. Additive — the existing `.` entry is unchanged, so `import { FinTSClient } from 'lib-fints'` is unaffected.

## Why

Node and Deno both enforce the `exports` field: any subpath not listed is rejected with `ERR_PACKAGE_PATH_NOT_EXPORTED`. With only `.` exported, deep imports of compiled modules are blocked. This affects consumers that need classes which aren't re-exported from the index — for example subclassing `CustomerOrderInteraction` to issue a custom order — and especially Deno-based runtimes (edge functions, Deno Deploy, Cloudflare Workers with Node compat), where there is no `node_modules` to reach into as a fallback.

## Verification

Packed the tarball both ways and imported it as a real consumer (Node enforces `exports` identically to Deno):

| import | before | after |
|---|---|---|
| `lib-fints` (root) | resolves | resolves |
| `lib-fints/dist/segments/registry.js` | `ERR_PACKAGE_PATH_NOT_EXPORTED` | resolves |
| `lib-fints/dist/interactions/customerInteraction.js` | `ERR_PACKAGE_PATH_NOT_EXPORTED` | resolves |

Build is clean and all existing tests pass.