### PR TITLE
Fix request encoding: use latin1 instead of default UTF-8 in HttpClient.sendMessage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,6 @@
 	},
 	"[json]": {
 		"editor.defaultFormatter": "biomejs.biome"
-	}
+	},
+	"js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -9,7 +9,7 @@ export class HttpClient {
 
 	async sendMessage(message: CustomerMessage): Promise<Message> {
 		const encodedMessage = message.encode();
-		const requestBuffer = Buffer.from(encodedMessage);
+        const requestBuffer = Buffer.from(encodedMessage, 'latin1');
 
 		if (this.debug) {
 			console.log('Request Message:\n');

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -9,7 +9,7 @@ export class HttpClient {
 
 	async sendMessage(message: CustomerMessage): Promise<Message> {
 		const encodedMessage = message.encode();
-        const requestBuffer = Buffer.from(encodedMessage, 'latin1');
+		const requestBuffer = Buffer.from(encodedMessage, 'latin1');
 
 		if (this.debug) {
 			console.log('Request Message:\n');


### PR DESCRIPTION
## Problem

`HttpClient.sendMessage()` encodes the outgoing request with `Buffer.from(encodedMessage)`,
which defaults to UTF-8. FinTS is a single-byte ISO-8859-1 protocol, and the message's own
`HNHBK` length header is computed from the JS string's character count (one unit per
character). Any non-ASCII character - e.g. a German umlaut (ä/ö/ü/ß), which is common in
this protocol's actual data (TAN media names, Verwendungszweck, account holder names) -
gets encoded as 2 bytes in UTF-8 instead of 1, so the declared message length no longer
matches the actual byte count sent. The bank then rejects the message as malformed.

The response side already handles this correctly with `responseBuffer.toString('latin1')`
a few lines down - the request encoding just doesn't match it.

## Reproduction

Selecting a TAN medium with an umlaut in its name (e.g. `config.tanMediaName = 'Alle Geräte'`) reliably triggers this. The bank
returns a low-level syntax error rather than a business error, e.g.:

    9130: abschliessendes Trennzeichen fehlt   (closing delimiter missing)

confirming the message was cut off mid-stream due to the byte/length mismatch, not rejected
for a business reason.

## Fix

One-line change: encode the request buffer as `latin1` to match how the response is already
decoded.